### PR TITLE
Updated the README.md to add the updated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### View the Tutorial
 
-The tutorial for this can be found at [http://docs.nitrous.io/v1.0/docs/add-a-bootstrap-layout-for-rails](http://docs.nitrous.io/v1.0/docs/add-a-bootstrap-layout-for-rails)
+The tutorial for this can be found at [http://docs.nitrous.io/v1.0/docs/add-a-bootstrap-layout-to-a-rails-app](http://docs.nitrous.io/v1.0/docs/add-a-bootstrap-layout-to-a-rails-app)
 
 ### Getting Started
 


### PR DESCRIPTION
The link has been updated on the website and is no longer http://docs.nitrous.io/v1.0/docs/add-a-bootstrap-layout-for-rails